### PR TITLE
High Priority API Mock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+default:
+	air --build.cmd "go build -o /tmp/vsc-go-mimic cmd/main.go" --build.bin "/tmp/vsc-go-mimic"

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,5 @@
 default:
+	go run ./cmd/main.go
+
+dev:
 	air --build.cmd "go build -o /tmp/vsc-go-mimic cmd/main.go" --build.bin "/tmp/vsc-go-mimic"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"context"
 	"mimic/modules/aggregate"
+	"mimic/modules/api"
 	"mimic/modules/db"
 	"mimic/modules/db/mimic"
 	"mimic/modules/db/mimic/blocks"
@@ -25,5 +27,10 @@ func main() {
 	agg := aggregate.New(plugins)
 
 	agg.Init()
-	agg.Start()
+	agg.Start().Await(context.Background())
+	defer agg.Stop()
+
+	router := api.NewAPIServer()
+	router.Init()
+	router.Start()
 }

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,10 @@
+services:
+  mongodb:
+    image: mongo:8.0.10-noble
+    container_name: vsc_go-mimic_mongodb
+    restart: always
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: example
+    ports:
+      - 27017:27017

--- a/lib/utils/env.go
+++ b/lib/utils/env.go
@@ -1,0 +1,24 @@
+package utils
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+)
+
+func EnvOrPanic(key string) string {
+	value, ok := os.LookupEnv(key)
+	if !ok {
+		panic(fmt.Sprintf("environment variable not set: `%s`", key))
+	}
+	return value
+}
+
+func EnvOrDefault(key, defaultValue string) string {
+	value, ok := os.LookupEnv(key)
+	if !ok {
+		slog.Warn("Environment variable not set, using default.", "key", key, "default", defaultValue)
+		return defaultValue
+	}
+	return value
+}

--- a/mockdata/block_api.get_block.mock.json
+++ b/mockdata/block_api.get_block.mock.json
@@ -1,0 +1,30 @@
+{
+  "0": {
+    "block": {
+      "block_id": "0000000109833ce528d5bbfb3f6225b39ee10086",
+      "extensions": [],
+      "previous": "0000000000000000000000000000000000000000",
+      "signing_key": "STM8GC13uCZbP44HzMLV6zPZGwVQ8Nt4Kji8PapsPiNq1BK153XTX",
+      "timestamp": "2016-03-24T16:05:00",
+      "transaction_ids": [],
+      "transaction_merkle_root": "0000000000000000000000000000000000000000",
+      "transactions": [],
+      "witness": "initminer",
+      "witness_signature": "204f8ad56a8f5cf722a02b035a61b500aa59b9519b2c33c77a80c0a714680a5a5a7a340d909d19996613c5e4ae92146b9add8a7a663eef37d837ef881477313043"
+    }
+  },
+  "1": {
+    "block": {
+      "block_id": "000000027a4b8ef1c2d9a5f8e3b6c4d7a1e9f2b8",
+      "extensions": [],
+      "previous": "0000000109833ce528d5bbfb3f6225b39ee10086",
+      "signing_key": "STM8GC13uCZbP44HzMLV6zPZGwVQ8Nt4Kji8PapsPiNq1BK153XTX",
+      "timestamp": "2016-03-25T16:05:00",
+      "transaction_ids": [],
+      "transaction_merkle_root": "0000000000000000000000000000000000000000",
+      "transactions": [],
+      "witness": "initminer",
+      "witness_signature": "204f8ad56a8f5cf722a02b035a61b500aa59b9519b2c33c77a80c0a714680a5a5a7a340d909d19996613c5e4ae92146b9add8a7a663eef37d837ef881477313043"
+    }
+  }
+}

--- a/mockdata/condenser_api_get_accounts.mock.json
+++ b/mockdata/condenser_api_get_accounts.mock.json
@@ -1,0 +1,239 @@
+{
+    "hiveio": {
+      "active": {
+        "account_auths": [
+          [
+            "pettycash",
+            1
+          ]
+        ],
+        "key_auths": [
+          [
+            "STM69zfrFGnZtU3gWFWpQJ6GhND1nz7TJsKBTjcWfebS1JzBEweQy",
+            1
+          ]
+        ],
+        "weight_threshold": 1
+      },
+      "balance": "743.431 HIVE",
+      "can_vote": true,
+      "comment_count": 0,
+      "created": "2020-03-06T12:22:51",
+      "curation_rewards": 20,
+      "delayed_votes": [],
+      "delegated_vesting_shares": "0.000000 VESTS",
+      "downvote_manabar": {
+        "current_mana": 5831078449,
+        "last_update_time": 1735711413
+      },
+      "governance_vote_expiration_ts": "2026-05-11T00:45:09",
+      "guest_bloggers": [],
+      "hbd_balance": "0.000 HBD",
+      "hbd_last_interest_payment": "2020-10-21T02:45:12",
+      "hbd_seconds": "0",
+      "hbd_seconds_last_update": "2020-10-21T02:45:12",
+      "id": 1370484,
+      "json_metadata": "",
+      "last_account_recovery": "1970-01-01T00:00:00",
+      "last_account_update": "2021-11-09T21:56:27",
+      "last_owner_update": "1970-01-01T00:00:00",
+      "last_post": "2025-03-20T16:39:33",
+      "last_root_post": "2025-03-20T16:39:33",
+      "last_vote_time": "2025-01-01T06:03:33",
+      "lifetime_vote_count": 0,
+      "market_history": [],
+      "memo_key": "STM7wrsg1BZogeK7X3eG4ivxmLaH69FomR8rLkBbepb3z3hm5SbXu",
+      "mined": false,
+      "name": "hiveio",
+      "next_vesting_withdrawal": "1969-12-31T23:59:59",
+      "open_recurrent_transfers": 0,
+      "other_history": [],
+      "owner": {
+        "account_auths": [],
+        "key_auths": [
+          [
+            "STM65PUAPA4yC4RgPtGgsPupxT6yJtMhmT5JHFdsT3uoCbR8WJ25s",
+            1
+          ]
+        ],
+        "weight_threshold": 1
+      },
+      "pending_claimed_accounts": 0,
+      "pending_transfers": 0,
+      "post_bandwidth": 0,
+      "post_count": 80,
+      "post_history": [],
+      "post_voting_power": "23324.313796 VESTS",
+      "posting": {
+        "account_auths": [
+          [
+            "threespeak",
+            1
+          ],
+          [
+            "vimm.app",
+            1
+          ]
+        ],
+        "key_auths": [
+          [
+            "STM6vJmrwaX5TjgTS9dPH8KsArso5m91fVodJvv91j7G765wqcNM9",
+            1
+          ]
+        ],
+        "weight_threshold": 1
+      },
+      "posting_json_metadata": "{\"profile\":{\"pinned\":\"none\",\"version\":2,\"website\":\"hive.io\",\"profile_image\":\"https://files.peakd.com/file/peakd-hive/hiveio/Jp2YHc6Q-hive-logo.png\",\"cover_image\":\"https://files.peakd.com/file/peakd-hive/hiveio/Xe1TcEBi-hive-banner.png\"}}",
+      "posting_rewards": 1919844,
+      "previous_owner_update": "1970-01-01T00:00:00",
+      "proxied_vsf_votes": [
+        0,
+        0,
+        0,
+        0
+      ],
+      "proxy": "",
+      "received_vesting_shares": "0.000000 VESTS",
+      "recovery_account": "steempeak",
+      "reputation": 0,
+      "reset_account": "null",
+      "reward_hbd_balance": "50.418 HBD",
+      "reward_hive_balance": "0.000 HIVE",
+      "reward_vesting_balance": "291242.001054 VESTS",
+      "reward_vesting_hive": "171.636 HIVE",
+      "savings_balance": "0.000 HIVE",
+      "savings_hbd_balance": "0.000 HBD",
+      "savings_hbd_last_interest_payment": "1970-01-01T00:00:00",
+      "savings_hbd_seconds": "0",
+      "savings_hbd_seconds_last_update": "1970-01-01T00:00:00",
+      "savings_withdraw_requests": 0,
+      "tags_usage": [],
+      "to_withdraw": 0,
+      "transfer_history": [],
+      "vesting_balance": "0.000 HIVE",
+      "vesting_shares": "23324.313796 VESTS",
+      "vesting_withdraw_rate": "0.000000 VESTS",
+      "vote_history": [],
+      "voting_manabar": {
+        "current_mana": 22857989494,
+        "last_update_time": 1735711413
+      },
+      "voting_power": 9800,
+      "withdraw_routes": 0,
+      "withdrawn": 0,
+      "witness_votes": [],
+      "witnesses_voted_for": 0
+    },
+    "alice": {
+      "active": {
+        "account_auths": [],
+        "key_auths": [
+          [
+            "STM6C6tnACdTfT5uLU3rNDLJ8nZ7hMM7begfbxEwCDPJxsnJAP9U2",
+            1
+          ]
+        ],
+        "weight_threshold": 1
+      },
+      "balance": "3.297 HIVE",
+      "can_vote": true,
+      "comment_count": 0,
+      "created": "2016-03-25T15:09:30",
+      "curation_rewards": 69,
+      "delayed_votes": [],
+      "delegated_vesting_shares": "0.000000 VESTS",
+      "downvote_manabar": {
+        "current_mana": 0,
+        "last_update_time": 1458918567
+      },
+      "governance_vote_expiration_ts": "1969-12-31T23:59:59",
+      "guest_bloggers": [],
+      "hbd_balance": "0.020 HBD",
+      "hbd_last_interest_payment": "2018-10-10T08:00:00",
+      "hbd_seconds": "1259928",
+      "hbd_seconds_last_update": "2018-10-11T02:25:12",
+      "id": 240,
+      "json_metadata": "",
+      "last_account_recovery": "1970-01-01T00:00:00",
+      "last_account_update": "1970-01-01T00:00:00",
+      "last_owner_update": "1970-01-01T00:00:00",
+      "last_post": "1970-01-01T00:00:00",
+      "last_root_post": "1970-01-01T00:00:00",
+      "last_vote_time": "2016-04-29T22:28:00",
+      "lifetime_vote_count": 0,
+      "market_history": [],
+      "memo_key": "STM6C6tnACdTfT5uLU3rNDLJ8nZ7hMM7begfbxEwCDPJxsnJAP9U2",
+      "mined": true,
+      "name": "alice",
+      "next_vesting_withdrawal": "1969-12-31T23:59:59",
+      "open_recurrent_transfers": 0,
+      "other_history": [],
+      "owner": {
+        "account_auths": [],
+        "key_auths": [
+          [
+            "STM6C6tnACdTfT5uLU3rNDLJ8nZ7hMM7begfbxEwCDPJxsnJAP9U2",
+            1
+          ]
+        ],
+        "weight_threshold": 1
+      },
+      "pending_claimed_accounts": 0,
+      "pending_transfers": 0,
+      "post_bandwidth": 0,
+      "post_count": 0,
+      "post_history": [],
+      "post_voting_power": "133609.394597 VESTS",
+      "posting": {
+        "account_auths": [],
+        "key_auths": [
+          [
+            "STM6C6tnACdTfT5uLU3rNDLJ8nZ7hMM7begfbxEwCDPJxsnJAP9U2",
+            1
+          ]
+        ],
+        "weight_threshold": 1
+      },
+      "posting_json_metadata": "",
+      "posting_rewards": 0,
+      "previous_owner_update": "1970-01-01T00:00:00",
+      "proxied_vsf_votes": [
+        0,
+        0,
+        0,
+        0
+      ],
+      "proxy": "",
+      "received_vesting_shares": "0.000000 VESTS",
+      "recovery_account": "steem",
+      "reputation": 0,
+      "reset_account": "null",
+      "reward_hbd_balance": "0.000 HBD",
+      "reward_hive_balance": "0.000 HIVE",
+      "reward_vesting_balance": "0.000000 VESTS",
+      "reward_vesting_hive": "0.000 HIVE",
+      "savings_balance": "0.000 HIVE",
+      "savings_hbd_balance": "0.000 HBD",
+      "savings_hbd_last_interest_payment": "1970-01-01T00:00:00",
+      "savings_hbd_seconds": "0",
+      "savings_hbd_seconds_last_update": "1970-01-01T00:00:00",
+      "savings_withdraw_requests": 0,
+      "tags_usage": [],
+      "to_withdraw": 0,
+      "transfer_history": [],
+      "vesting_balance": "0.000 HIVE",
+      "vesting_shares": "133609.394597 VESTS",
+      "vesting_withdraw_rate": "0.000000 VESTS",
+      "vote_history": [],
+      "voting_manabar": {
+        "current_mana": 9899,
+        "last_update_time": 1461968880
+      },
+      "voting_power": 9899,
+      "withdraw_routes": 0,
+      "withdrawn": 0,
+      "witness_votes": [],
+      "witnesses_voted_for": 0
+    }
+
+}

--- a/modules/aggregate/aggregate.go
+++ b/modules/aggregate/aggregate.go
@@ -58,8 +58,8 @@ func (a *Aggregate) Start() *promise.Promise[any] {
 	return promise.Then(
 		promise.All(a.ctx, promises...),
 		a.ctx,
-		func([]any) (any, error) {
-			return nil, nil
+		func(arg []any) (any, error) {
+			return arg, nil
 		},
 	)
 }

--- a/modules/api/api.go
+++ b/modules/api/api.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"log/slog"
 	"net/http"
 	"reflect"
@@ -90,6 +91,8 @@ func (s *APIServer) Init() {
 		if err != nil {
 			fmt.Println("args", args, err)
 		}
+
+		log.Println(args)
 
 		reply := reflect.New(s.rpcRoutes[method].replyType)
 

--- a/modules/api/api.go
+++ b/modules/api/api.go
@@ -71,8 +71,6 @@ func (s *APIServer) Init() {
 			return
 		}
 
-		fmt.Println("req", req)
-
 		method, valid := req["method"].(string)
 
 		if !valid {
@@ -89,8 +87,9 @@ func (s *APIServer) Init() {
 
 		args := reflect.New(methodSpec.argType)
 		err := mapstructure.Decode(req["params"], args.Interface())
-
-		fmt.Println("args", args, err)
+		if err != nil {
+			fmt.Println("args", args, err)
+		}
 
 		reply := reflect.New(s.rpcRoutes[method].replyType)
 
@@ -101,8 +100,6 @@ func (s *APIServer) Init() {
 			reply,
 		})
 
-		fmt.Println("req[\"Method\"]", req["method"], reply)
-
 		res := map[string]any{
 			"jsonrpc": "2.0",
 			"result":  reply.Interface(),
@@ -110,7 +107,7 @@ func (s *APIServer) Init() {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-
+		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(res)
 	})
 

--- a/modules/api/api.go
+++ b/modules/api/api.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"reflect"
 	"strings"
@@ -24,20 +25,18 @@ type APIServer struct {
 
 func (s *APIServer) RegisterMethod(alias, methodName string, servc any) ServiceMethod {
 	servType := reflect.TypeOf(servc)
+
 	method, success := servType.MethodByName(methodName)
-
-	for i := 0; i < servType.NumMethod(); i++ {
-		fmt.Println("method", servType.Method(i).Name)
-	}
-
-	fmt.Println("method", methodName, method, servType)
 	if !success {
 		panic("method not found")
 	}
 
+	slog.Info("Method registered.",
+		"methodName", methodName,
+		"methodNum", servType.NumMethod())
+
 	mtype := method.Type
 
-	fmt.Println("mtype.NumIn()", success)
 	return ServiceMethod{
 		method:    method,
 		argType:   mtype.In(1).Elem(),
@@ -130,7 +129,9 @@ func (s *APIServer) Start() {
 	s.RegisterService(blockApi, "block_api")
 	s.RegisterService(accountHistoryApi, "account_history_api")
 
-	go http.ListenAndServe(":3000", s.r)
+	port := "3000"
+	slog.Info("APIServer accepting requests.", "port", port)
+	http.ListenAndServe(":"+port, s.r)
 }
 
 func NewAPIServer() *APIServer {

--- a/modules/api/services/block_api.go
+++ b/modules/api/services/block_api.go
@@ -1,5 +1,11 @@
 package services
 
+import (
+	"fmt"
+
+	"golang.org/x/exp/slog"
+)
+
 type BlockAPI struct {
 }
 
@@ -33,8 +39,19 @@ type GetBlockReply struct {
 	Block getBlockBlock `json:"block"`
 }
 
-func (BlockAPI) GetBlock(args *GetBlockArgs, reply *GetBlockRangeReply) {
+func (BlockAPI) GetBlock(args *GetBlockArgs, reply *GetBlockReply) {
+	data, err := getMockData[GetBlockReply]("mockdata/block_api.get_block.mock.json")
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(args)
 
+	block, ok := data[fmt.Sprintf("%d", args.BlockNum)]
+	if !ok {
+		slog.Error("Block not found.", "block_num", args.BlockNum)
+	} else {
+		*reply = block
+	}
 }
 
 func (BlockAPI) Expose(rm RegisterMethod) {

--- a/modules/api/services/block_api.go
+++ b/modules/api/services/block_api.go
@@ -10,13 +10,28 @@ type BlockAPI struct {
 }
 
 type GetBlockRangeArgs struct {
+	StartingBlockNum int `json:"starting_block_num"`
+	Count            int `json:"count"`
 }
 
 type GetBlockRangeReply struct {
+	Blocks []getBlockBlock `json:"blocks"`
 }
 
 func (BlockAPI) GetBlockRange(args *GetBlockRangeArgs, reply *GetBlockRangeReply) {
+	data, err := getMockData[GetBlockReply]("mockdata/block_api.get_block.mock.json")
+	if err != nil {
+		panic(err)
+	}
 
+	for i := 0; i <= args.Count; i++ {
+		blockIndex := fmt.Sprintf("%d", args.StartingBlockNum+i)
+		block, ok := data[blockIndex]
+		if !ok {
+			continue
+		}
+		reply.Blocks = append(reply.Blocks, block.Block)
+	}
 }
 
 type GetBlockArgs struct {
@@ -44,7 +59,6 @@ func (BlockAPI) GetBlock(args *GetBlockArgs, reply *GetBlockReply) {
 	if err != nil {
 		panic(err)
 	}
-	fmt.Println(args)
 
 	block, ok := data[fmt.Sprintf("%d", args.BlockNum)]
 	if !ok {

--- a/modules/api/services/condenser.go
+++ b/modules/api/services/condenser.go
@@ -175,15 +175,11 @@ type GetAccountsReply struct {
 	LifetimeVoteCount   int              `json:"lifetime_vote_count"`
 	PostCount           int              `json:"post_count"`
 	CanVote             bool             `json:"can_vote"`
-	VotingManabar       struct {
-		CurrentMana    string `json:"current_mana"`
-		LastUpdateTime int    `json:"last_update_time"`
-	} `json:"voting_manabar"`
-	DownvoteManabar struct {
-		CurrentMana    string `json:"current_mana"`
-		LastUpdateTime int    `json:"last_update_time"`
-	} `json:"downvote_manabar"`
-	VotingPower                   int    `json:"voting_power"`
+
+	VotingManabar   VotingManabar   `json:"voting_manabar"`
+	DownvoteManabar DownvoteManabar `json:"downvote_manabar"`
+	VotingPower     int             `json:"voting_power"`
+
 	Balance                       string `json:"balance"`
 	SavingsBalance                string `json:"savings_balance"`
 	HbdBalance                    string `json:"hbd_balance"`
@@ -230,6 +226,16 @@ type GetAccountsReply struct {
 	WitnessVotes           []any  `json:"witness_votes"`
 	TagsUsage              []any  `json:"tags_usage"`
 	GuestBloggers          []any  `json:"guest_bloggers"`
+}
+
+type VotingManabar struct {
+	CurrentMana    string `json:"current_mana"`
+	LastUpdateTime int    `json:"last_update_time"`
+}
+
+type DownvoteManabar struct {
+	CurrentMana    string `json:"current_mana"`
+	LastUpdateTime int    `json:"last_update_time"`
 }
 
 // get_accounts

--- a/modules/api/services/condenser.go
+++ b/modules/api/services/condenser.go
@@ -1,6 +1,10 @@
 package services
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
 
 type TestMethodArgs struct {
 	A int `json:"a"`
@@ -154,7 +158,7 @@ type AccountAuthority struct {
 	AccountAuths    []interface{} `json:"account_auths"`
 	KeyAuths        []interface{} `json:"key_auths"`
 }
-type GetAccountsReply struct {
+type GetAccountsData struct {
 	Id                  int              `json:"id"`
 	Name                string           `json:"name"`
 	Owner               AccountAuthority `json:"owner"`
@@ -217,7 +221,7 @@ type GetAccountsReply struct {
 	PendingClaimedAccounts int    `json:"pending_claimed_accounts"`
 	DelayedVotes           []any  `json:"delayed_votes"`
 	VestingBalance         string `json:"vesting_balance"`
-	Reputation             string `json:"reputation"`
+	Reputation             int    `json:"reputation"`
 	TransferHistory        []any  `json:"transfer_history"`
 	MarketHistory          []any  `json:"market_history"`
 	PostHistory            []any  `json:"post_history"`
@@ -229,109 +233,59 @@ type GetAccountsReply struct {
 }
 
 type VotingManabar struct {
-	CurrentMana    string `json:"current_mana"`
-	LastUpdateTime int    `json:"last_update_time"`
+	CurrentMana    int `json:"current_mana"`
+	LastUpdateTime int `json:"last_update_time"`
 }
 
 type DownvoteManabar struct {
-	CurrentMana    string `json:"current_mana"`
-	LastUpdateTime int    `json:"last_update_time"`
+	CurrentMana    int `json:"current_mana"`
+	LastUpdateTime int `json:"last_update_time"`
+}
+
+type GetAccountsReply struct {
+	ID             int               `json:"id"`
+	JsonRpcVersion string            `json:"jsonrpc"`
+	Result         []GetAccountsData `json:"result"`
+}
+
+func getMockData(accountName string) (*GetAccountsData, error) {
+	// TODO: propagate this into db
+	f, err := os.ReadFile("mockdata/condenser_api_get_accounts.mock.json")
+	if err != nil {
+		fmt.Println("failed to read mockdata")
+		panic(err)
+	}
+
+	data := make(map[string]GetAccountsData)
+	if err := json.Unmarshal(f, &data); err != nil {
+		panic(err)
+	}
+
+	account, ok := data[accountName]
+	if !ok {
+		return nil, fmt.Errorf("account not found: %s\n", accountName)
+	}
+
+	return &account, nil
 }
 
 // get_accounts
-func (t *Condenser) GetAccounts(args *GetAccountsArgs, reply *[]GetAccountsReply) {
-
-	for _, account := range *args {
-		*reply = append(*reply, GetAccountsReply{
-			Id:   1,
-			Name: account[0],
-			Owner: AccountAuthority{
-				WeightThreshold: 1,
-				AccountAuths: []interface{}{
-					1, "",
-				},
-				KeyAuths: []interface{}{},
-			},
-			Active: AccountAuthority{
-				WeightThreshold: 1,
-				AccountAuths:    []interface{}{},
-				KeyAuths:        []interface{}{},
-			},
-			Posting: AccountAuthority{
-				WeightThreshold: 1,
-				AccountAuths:    []interface{}{},
-				KeyAuths:        []interface{}{},
-			},
-			VotingManabar: struct {
-				CurrentMana    string `json:"current_mana"`
-				LastUpdateTime int    `json:"last_update_time"`
-			}{
-				CurrentMana:    "1000000000",
-				LastUpdateTime: 1000000000,
-			},
-			MemoKey:                       "STM7wrsg1BZogeK7X3eG4ivxmLaH69FomR8rLkBbepb3z3hm5SbXu",
-			JsonMeta:                      "",
-			Proxy:                         "",
-			Created:                       "2023-10-01T00:00:00",
-			Mined:                         false,
-			RecoveryAccount:               "test",
-			LastAccountRecovery:           "2023-10-01T00:00:00",
-			ResetAccount:                  "null",
-			CommentCount:                  0,
-			LifetimeVoteCount:             0,
-			PostCount:                     0,
-			CanVote:                       true,
-			VotingPower:                   0,
-			Balance:                       "1.100 HIVE",
-			SavingsBalance:                "1.200 HIVE",
-			HbdBalance:                    "1.300 HBD",
-			HbdSeconds:                    "0",
-			HbdSecondsLastUpdate:          "2023-10-01T00:00:00",
-			HbdLastInterestPayment:        "2023-10-01T00:00:00",
-			SavingsHbdBalance:             "10.000 HBD",
-			SavingsHbdSeconds:             "0",
-			SavingsHbdSecondsLastUpdate:   "2023-10-01T00:00:00",
-			SavingsHbdLastInterestPayment: "2023-10-01T00:00:00",
-			SavingsWithdrawRequests:       0,
-			RewardHbdBalance:              "0.000 HBD",
-			RewardHiveBalance:             "0.000 HIVE",
-			RewardVestingBalance:          "0.000000 VESTS",
-			RewardVestingHive:             "0.000 HIVE",
-			VestingShares:                 "10000000.000000 VESTS",
-			DelegatedVestingShares:        "0.000000 VESTS",
-			ReceivedVestingShares:         "0.000000 VESTS",
-
-			VestingWithdrawRate:    "0.000000 VESTS",
-			PostVotingPower:        "0.000000 VESTS",
-			NextVestingWithdrawal:  "2023-10-01T00:00:00",
-			Withdrawn:              0,
-			ToWithdraw:             0,
-			WithdrawRoutes:         0,
-			PendingTransfers:       0,
-			CurationRewards:        0,
-			PostingRewards:         0,
-			ProxiedVsfVotes:        []int{0, 0, 0, 0},
-			WitnessesVotedFor:      0,
-			LastPost:               "2023-10-01T00:00:00",
-			LastRootPost:           "2023-10-01T00:00:00",
-			LastVoteTime:           "2023-10-01T00:00:00",
-			PostBandwidth:          0,
-			PendingClaimedAccounts: 0,
-			DelayedVotes:           []any{},
-			VestingBalance:         "10000000.000000 VESTS",
-			Reputation:             "0",
-			TransferHistory:        []any{},
-			MarketHistory:          []any{},
-			PostHistory:            []any{},
-			VoteHistory:            []any{},
-			OtherHistory:           []any{},
-			WitnessVotes:           []any{},
-			TagsUsage:              []any{},
-			GuestBloggers:          []any{},
-		})
-		fmt.Println("act", account[0])
+func (t *Condenser) GetAccounts(args *GetAccountsArgs, reply *[]GetAccountsData) {
+	for _, a := range *args {
+		accountName := a[0]
+		account, err := getMockData(accountName)
+		if err != nil {
+			// TODO: handle this error from db
+			// NOTE: if not found, do what?
+			//   - accounts partially exist
+			//   - accounts do not exist at all
+			// from the current implementation we just don't send anything back
+			// (empty result array)
+			fmt.Println("no account found")
+			continue
+		}
+		*reply = append(*reply, *account)
 	}
-	fmt.Println("GetAccounts", args)
 }
 
 //	{

--- a/modules/api/services/condenser.go
+++ b/modules/api/services/condenser.go
@@ -242,7 +242,7 @@ type DownvoteManabar struct {
 	LastUpdateTime int `json:"last_update_time"`
 }
 
-func getMockData(accountName string) (*GetAccountsReply, error) {
+func getMockDataa(accountName string) (*GetAccountsReply, error) {
 	// TODO: propagate this into db
 	f, err := os.ReadFile("mockdata/condenser_api_get_accounts.mock.json")
 	if err != nil {
@@ -265,10 +265,15 @@ func getMockData(accountName string) (*GetAccountsReply, error) {
 
 // get_accounts
 func (t *Condenser) GetAccounts(args *GetAccountsArgs, reply *[]GetAccountsReply) {
+	data, err := getMockData[GetAccountsReply]("mockdata/condenser_api_get_accounts.mock.json")
+	if err != nil {
+		panic(err)
+	}
+
 	for _, a := range *args {
 		accountName := a[0]
-		account, err := getMockData(accountName)
-		if err != nil {
+		account, ok := data[accountName]
+		if !ok {
 			// TODO: handle this error from db
 			// NOTE: if not found, do what?
 			//   - accounts partially exist
@@ -278,7 +283,7 @@ func (t *Condenser) GetAccounts(args *GetAccountsArgs, reply *[]GetAccountsReply
 			fmt.Println("no account found")
 			continue
 		}
-		*reply = append(*reply, *account)
+		*reply = append(*reply, account)
 	}
 }
 

--- a/modules/api/services/condenser.go
+++ b/modules/api/services/condenser.go
@@ -158,7 +158,7 @@ type AccountAuthority struct {
 	AccountAuths    []interface{} `json:"account_auths"`
 	KeyAuths        []interface{} `json:"key_auths"`
 }
-type GetAccountsData struct {
+type GetAccountsReply struct {
 	Id                  int              `json:"id"`
 	Name                string           `json:"name"`
 	Owner               AccountAuthority `json:"owner"`
@@ -242,13 +242,7 @@ type DownvoteManabar struct {
 	LastUpdateTime int `json:"last_update_time"`
 }
 
-type GetAccountsReply struct {
-	ID             int               `json:"id"`
-	JsonRpcVersion string            `json:"jsonrpc"`
-	Result         []GetAccountsData `json:"result"`
-}
-
-func getMockData(accountName string) (*GetAccountsData, error) {
+func getMockData(accountName string) (*GetAccountsReply, error) {
 	// TODO: propagate this into db
 	f, err := os.ReadFile("mockdata/condenser_api_get_accounts.mock.json")
 	if err != nil {
@@ -256,7 +250,7 @@ func getMockData(accountName string) (*GetAccountsData, error) {
 		panic(err)
 	}
 
-	data := make(map[string]GetAccountsData)
+	data := make(map[string]GetAccountsReply)
 	if err := json.Unmarshal(f, &data); err != nil {
 		panic(err)
 	}
@@ -270,7 +264,7 @@ func getMockData(accountName string) (*GetAccountsData, error) {
 }
 
 // get_accounts
-func (t *Condenser) GetAccounts(args *GetAccountsArgs, reply *[]GetAccountsData) {
+func (t *Condenser) GetAccounts(args *GetAccountsArgs, reply *[]GetAccountsReply) {
 	for _, a := range *args {
 		accountName := a[0]
 		account, err := getMockData(accountName)

--- a/modules/api/services/condenser.go
+++ b/modules/api/services/condenser.go
@@ -1,9 +1,7 @@
 package services
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
 )
 
 type TestMethodArgs struct {
@@ -240,27 +238,6 @@ type VotingManabar struct {
 type DownvoteManabar struct {
 	CurrentMana    int `json:"current_mana"`
 	LastUpdateTime int `json:"last_update_time"`
-}
-
-func getMockDataa(accountName string) (*GetAccountsReply, error) {
-	// TODO: propagate this into db
-	f, err := os.ReadFile("mockdata/condenser_api_get_accounts.mock.json")
-	if err != nil {
-		fmt.Println("failed to read mockdata")
-		panic(err)
-	}
-
-	data := make(map[string]GetAccountsReply)
-	if err := json.Unmarshal(f, &data); err != nil {
-		panic(err)
-	}
-
-	account, ok := data[accountName]
-	if !ok {
-		return nil, fmt.Errorf("account not found: %s\n", accountName)
-	}
-
-	return &account, nil
 }
 
 // get_accounts

--- a/modules/api/services/mockdata.go
+++ b/modules/api/services/mockdata.go
@@ -6,7 +6,7 @@ import (
 )
 
 func getMockData[T any](mockPath string) (map[string]T, error) {
-	// TODO: propagate this into db
+	// TODO: save to mock data to db
 	f, err := os.ReadFile(mockPath)
 	if err != nil {
 		return nil, err
@@ -16,6 +16,6 @@ func getMockData[T any](mockPath string) (map[string]T, error) {
 	if err := json.Unmarshal(f, &data); err != nil {
 		return nil, err
 	}
-	return data, nil
 
+	return data, nil
 }

--- a/modules/api/services/mockdata.go
+++ b/modules/api/services/mockdata.go
@@ -1,0 +1,21 @@
+package services
+
+import (
+	"encoding/json"
+	"os"
+)
+
+func getMockData[T any](mockPath string) (map[string]T, error) {
+	// TODO: propagate this into db
+	f, err := os.ReadFile(mockPath)
+	if err != nil {
+		return nil, err
+	}
+
+	data := make(map[string]T)
+	if err := json.Unmarshal(f, &data); err != nil {
+		return nil, err
+	}
+	return data, nil
+
+}

--- a/modules/config/config.go
+++ b/modules/config/config.go
@@ -120,7 +120,10 @@ func (c *Config[T]) Stop() error {
 }
 
 func (c *Config[T]) Get() T {
-	return c.value
+	if c.loaded {
+		return c.value
+	}
+	return c.defaultValue
 }
 
 func (c *Config[T]) Update(updater func(*T)) error {

--- a/modules/db/config.go
+++ b/modules/db/config.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"errors"
+	"mimic/lib/utils"
 	"mimic/modules/config"
 	"os"
 )
@@ -20,7 +21,7 @@ type DbConfig = *dbConfigStruct
 
 func NewDbConfig() DbConfig {
 	return &dbConfigStruct{config.New(dbConfig{
-		DbURI: "mongodb://localhost:27017",
+		DbURI: utils.EnvOrDefault("MONGO_URL", "mongodb://localhost:27017"),
 	}, nil)}
 }
 

--- a/modules/db/db.go
+++ b/modules/db/db.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"log/slog"
 	"mimic/lib/utils"
 	a "mimic/modules/aggregate"
 
@@ -30,7 +31,8 @@ func (db *db) Init() error {
 	ctx, cancel := context.WithCancel(context.Background())
 	db.cancel = cancel
 
-	c, err := mongo.Connect(ctx, options.Client().ApplyURI(db.conf.Get().DbURI))
+	uri := db.conf.Get().DbURI
+	c, err := mongo.Connect(ctx, options.Client().ApplyURI(uri))
 	if err != nil {
 		return err
 	}
@@ -39,6 +41,8 @@ func (db *db) Init() error {
 		return err
 	}
 	db.Client = c
+
+	slog.Info("Connected to MongoDB.", "url", uri)
 
 	return nil
 }

--- a/modules/db/db.go
+++ b/modules/db/db.go
@@ -44,7 +44,7 @@ func (db *db) Init() error {
 }
 
 func (db *db) Start() *promise.Promise[any] {
-	return utils.PromiseResolve[any](nil)
+	return utils.PromiseResolve[any](db)
 }
 
 func (db *db) Stop() error {

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,22 @@ Mimic is an end to end network simulation tool for the Hive blockchain. It provi
 - Update account metadata or public keys via mock transactions
 - Perform real world transactions against a mock environment, respecting signature validation, balance validation, and transaction expiration
 
+## Getting Started
 
+In case you don't have the binaries installed locally. A `compose.yml` file is 
+given for MongoDB, exposing the default port `27017`.
+
+```sh
+docker compose up
+```
+
+Start the mimic server
+
+```sh
+go run ./cmd/main.go
+# or with Makefile
+make
+```
 
 ### Supported Transactions
 
@@ -29,8 +44,8 @@ Not all transactions are supported on Mimic. However, we have implemented the fo
 
 **Hive APIs**
 - `account_history_api.get_ops_in_block` 🚧
-- `block_api.get_block` 🚧
-- `block_api.get_block_range` 🚧
+- `block_api.get_block` ✅
+- `block_api.get_block_range` ✅
 - `condenser_api.broadcast_transaction` 🚧
 - `condenser_api.broadcast_transaction_synchronous` 🚧
 - `condenser_api.get_dynamic_global_properties` 🚧
@@ -40,7 +55,7 @@ Not all transactions are supported on Mimic. However, we have implemented the fo
 - `condenser_api.get_open_orders` 🚧
 - `condenser_api.get_conversion_requests` 🚧
 - `condenser_api.get_collateralized_conversion_requests` 🚧
-- `condenser_api.get_accounts` 🚧
+- `condenser_api.get_accounts` ✅
 - `rc_api.find_rc_accounts` 🚧
 - `/health` ✅
 

--- a/tests/requests/block_api.http
+++ b/tests/requests/block_api.http
@@ -1,4 +1,4 @@
-### get_block
+### block_api.get_block
 
 POST http://localhost:3000 HTTP/1.1
 Accept: application/json
@@ -9,4 +9,18 @@ Content-Type: application/json
   "method": "block_api.get_block",
   "params": { "block_num": 3 },
   "id": 3
+}
+
+
+### block_api.get_block_range
+POST http://localhost:3000 HTTP/1.1
+
+{
+  "jsonrpc":"2.0", 
+  "method":"block_api.get_block_range",
+  "params": {
+    "starting_block_num": 0,
+    "count": 1
+  }, 
+  "id":1
 }

--- a/tests/requests/block_api.http
+++ b/tests/requests/block_api.http
@@ -1,0 +1,12 @@
+### get_block
+
+POST http://localhost:3000 HTTP/1.1
+Accept: application/json
+Content-Type: application/json
+
+{
+  "jsonrpc": "2.0",
+  "method": "block_api.get_block",
+  "params": { "block_num": 3 },
+  "id": 3
+}

--- a/tests/requests/condenser.http
+++ b/tests/requests/condenser.http
@@ -1,0 +1,12 @@
+### condenser_api_get_accounts
+
+POST http://localhost:3000 HTTP/1.1
+Accept: application/json
+Content-Type: application/json
+
+{
+  "jsonrpc": "2.0",
+  "method": "condenser_api.get_accounts",
+  "params": [["hiveio", "alice"]],
+  "id": 1
+}


### PR DESCRIPTION
# Implemented
This PR mocked 3 high priority endpoints
- `condenser_api_get_accounts`
- `block_api.get_block`
- `block_api.get_block_range`

Additionally I've added some logging and initialized the plugins from the starting code.

# Bug fixes
One dep I have removed was [`mapstructure`](https://github.com/mitchellh/mapstructure), it wasn't serializing any struct with more than one field for me, and I found out that it has been unmaintained since July 22, 2024. The current fix is to just serialize it to json bytes again, the deserialize to the `reflect.Value` generic

# TODO
- So far the data is static, I have not yet written the mock data to MongoDB, I will implement that in the next PR, this one is to just get the high priority pulled so I'm not blocking testing.
- Not sure how to handle the not found case for all the endpoints so far, I may have missed it in Hive's documentation but I couldn't find that information anywhere, and with the current set up, one problem may come up with `condenser_api_get_accounts` when the account isn't found is the response is initialized with default values (empty strings, 0 for int, etc). Fixing this may require a relatively large refactoring.